### PR TITLE
Fix for failure if already at target

### DIFF
--- a/cob_hand_bridge/CMakeLists.txt
+++ b/cob_hand_bridge/CMakeLists.txt
@@ -47,7 +47,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}_node src/cob_hand_bridge_node.cpp)
 target_link_libraries(${PROJECT_NAME}_node ${Boost_LIBRARIES} ${catkin_LIBRARIES})
-add_dependencies(${PROJECT_NAME}_node ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS ${PROJECT_NAME}_node
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/cob_hand_bridge/CMakeLists.txt
+++ b/cob_hand_bridge/CMakeLists.txt
@@ -7,6 +7,7 @@ project(cob_hand_bridge)
 find_package(catkin REQUIRED COMPONENTS
   actionlib
   angles
+  control_msgs
   diagnostic_updater
   message_generation
   sensor_msgs

--- a/cob_hand_bridge/package.xml
+++ b/cob_hand_bridge/package.xml
@@ -16,6 +16,7 @@
 
   <depend>actionlib</depend>
   <depend>angles</depend>
+  <depend>control_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>


### PR DESCRIPTION
Should send success even if started at target.
(includes #1)
